### PR TITLE
chore: add local sdk source.

### DIFF
--- a/sdk/php/README.md
+++ b/sdk/php/README.md
@@ -38,3 +38,10 @@ You can launch a basic development environment by using the provided docker-comp
 4. Run the tests : `phpunit`
 
 You can regenerate the files by using the `./codegen` command
+
+## Developing with the PHP SDK runtime
+
+From a parent directory of the PHP SDK, run `dagger init --sdk=<path to dagger repo>/sdk/php`.
+
+This will use the PHP SDK runtime with local source code which will make the feedback loop much faster than
+pulling changes from the remote repository.

--- a/sdk/php/dagger.json
+++ b/sdk/php/dagger.json
@@ -1,0 +1,9 @@
+{
+  "name": "php-sdk",
+  "sdk": "go",
+  "include": [
+    "."
+  ],
+  "source": "runtime",
+  "engineVersion": "v0.11.6"
+}

--- a/sdk/php/runtime/dagger.json
+++ b/sdk/php/runtime/dagger.json
@@ -1,5 +1,0 @@
-{
-  "name": "php-sdk",
-  "sdk": "go",
-  "engineVersion": "v0.11.4"
-}

--- a/sdk/php/runtime/go.mod
+++ b/sdk/php/runtime/go.mod
@@ -1,3 +1,35 @@
 module php-sdk
 
 go 1.21.7
+
+require (
+	github.com/99designs/gqlgen v0.17.44
+	github.com/Khan/genqlient v0.7.0
+	github.com/vektah/gqlparser/v2 v2.5.11
+	go.opentelemetry.io/otel v1.26.0
+	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.26.0
+	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.26.0
+	go.opentelemetry.io/otel/sdk v1.26.0
+	go.opentelemetry.io/otel/trace v1.26.0
+	golang.org/x/exp v0.0.0-20231110203233-9a3e6036ecaa
+	golang.org/x/sync v0.7.0
+	google.golang.org/grpc v1.63.2
+)
+
+require (
+	github.com/cenkalti/backoff/v4 v4.3.0 // indirect
+	github.com/go-logr/logr v1.4.1 // indirect
+	github.com/go-logr/stdr v1.2.2 // indirect
+	github.com/google/uuid v1.6.0 // indirect
+	github.com/grpc-ecosystem/grpc-gateway/v2 v2.19.1 // indirect
+	github.com/sosodev/duration v1.2.0 // indirect
+	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.26.0 // indirect
+	go.opentelemetry.io/otel/metric v1.26.0 // indirect
+	go.opentelemetry.io/proto/otlp v1.2.0 // indirect
+	golang.org/x/net v0.23.0 // indirect
+	golang.org/x/sys v0.19.0 // indirect
+	golang.org/x/text v0.14.0 // indirect
+	google.golang.org/genproto/googleapis/api v0.0.0-20240227224415-6ceb2ff114de // indirect
+	google.golang.org/genproto/googleapis/rpc v0.0.0-20240401170217-c3f982113cda // indirect
+	google.golang.org/protobuf v1.33.0 // indirect
+)

--- a/sdk/php/runtime/main.go
+++ b/sdk/php/runtime/main.go
@@ -28,10 +28,12 @@ func New(
 	sdkSourceDir *Directory,
 ) *PhpSdk {
 	if sdkSourceDir == nil {
-		sdkSourceDir = dag.Git("https://github.com/carnage/dagger.git").
-			Branch("charjr-add-php-runtime").
-			Tree().
-			Directory("sdk/php")
+		// TODO: change back to git or something remote when the runtime is ready.
+		// Go back to ../ to get the root of the PHP SDK
+		// This is a bit of a hack, you need to call it from a parent directory but it works.
+		// Example from ../../ (the directory above the dagger git repo)
+		// dagger init --sdk=dagger/sdk/php --source=test
+		sdkSourceDir = dag.CurrentModule().Source().Directory("../").WithoutDirectory("runtime")
 	}
 
 	return &PhpSdk{


### PR DESCRIPTION
WARNING: this commit should be revert once when it's time to merge the SDK.

Move `dagger.json` to `sdk/php` to allow using the runtime from its local sources.